### PR TITLE
Install tcpdump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/ubuntu:18.04
-RUN apt-get update && apt-get install -y systemd dnsutils curl iproute2 netcat
+FROM docker.io/library/ubuntu:20.04
+RUN apt-get update && apt-get install -y systemd dnsutils curl iproute2 netcat tcpdump


### PR DESCRIPTION
It's going to be used by Wireguard tests in test/k8sT/Services.go to
check whether we don't leak any unencrypted traffic.

Signed-off-by: Martynas Pumputis <m@lambda.lt>