### PR TITLE
Add `conntrack` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM docker.io/library/ubuntu:20.04
-RUN apt-get update && apt-get install -y systemd dnsutils curl iproute2 netcat tcpdump
+RUN apt-get update && apt-get install -y systemd dnsutils curl iproute2 netcat tcpdump conntrack


### PR DESCRIPTION
This is needed to dump the Linux conntrack table in some tests. We currently install the package at runtime, but that is flaky as any connectivity issue can cause the download and install to fail.